### PR TITLE
Minor fixes to 2ccNML v3.1

### DIFF
--- a/src/Railbus-diesel/Italy_FS_ALn_668_graphics.pnml
+++ b/src/Railbus-diesel/Italy_FS_ALn_668_graphics.pnml
@@ -11,7 +11,7 @@
 */
 
 spriteset(spriteset_rbd_Italy_FS_ALn_668_purchase, "gfx/Railbus-diesel/Italy_FS_ALn_668.png") {
-	template_purchase_dualheaded(1, 32)
+	template_purchase(1, 32)
 }
 
 /*

--- a/src/vehicleID.pnml
+++ b/src/vehicleID.pnml
@@ -259,7 +259,7 @@ item(FEAT_TRAINS, item_diesel_Australia_Queensland_Rail_2100, 5039) {}
 item(FEAT_TRAINS, item_diesel_Croatia_HZ_2062, 5040) {}
 item(FEAT_TRAINS, item_diesel_Sweden_SJ_V4, 5041) {}
 item(FEAT_TRAINS, item_diesel_Canada_CNR_MLW_M420W, 5042) {}
-item(FEAT_TRAINS, item_diesel_USA_GNR_SDP_40F, 5043) {}
+item(FEAT_TRAINS, item_diesel_USA_Amtrack_SDP_40F, 5043) {}
 item(FEAT_TRAINS, item_diesel_China_China_Railways_DFH3, 5044) {}
 item(FEAT_TRAINS, item_diesel_Panama_Panama_Canal_Railway_EMD_F40PH, 5045) {}
 item(FEAT_TRAINS, item_diesel_Portugal_CP_1900, 5046) {}
@@ -359,7 +359,7 @@ item(FEAT_TRAINS, item_electric_UK_NER_EF1, 6002) {}
 item(FEAT_TRAINS, item_electric_USA_Milwaukee_Road_ES_2, 6003) {}
 //6004 free
 //6005 free
-item(FEAT_TRAINS, item_electric_Chile_EFE_Series_E_28, 6006) {}
+item(FEAT_TRAINS, item_electric_Chile_EFE_E_28, 6006) {}
 item(FEAT_TRAINS, item_electric_Austria_OBB_1161, 6007) {}
 item(FEAT_TRAINS, item_electric_India_Indian_Railways_WCG_1, 6008) {}
 item(FEAT_TRAINS, item_electric_Germany_DB_169, 6009) {}
@@ -765,7 +765,7 @@ item(FEAT_TRAINS, item_coach_Gen6_Super_Voyager_Coach, 11070) {}
 //Wagons, available ID range: 12000-12999 (hex 0x2EE0..0x32C7)
 #define ID_RANGE_WAGONS 0x2EE0..0x32C7
 item(FEAT_TRAINS, item_wagon_Gen1_Flat_Wagon, 12000) {}
-item(FEAT_TRAINS, item_wagon_Gen1_BoxCar, 12001) {}
+item(FEAT_TRAINS, item_wagon_Gen1_Boxcar, 12001) {}
 item(FEAT_TRAINS, item_wagon_Gen1_Tanker, 12002) {}
 item(FEAT_TRAINS, item_wagon_Gen1_Open_Wagon, 12003) {}
 item(FEAT_TRAINS, item_wagon_Gen2_Flat_Wagon, 12004) {}

--- a/src/vehiclesort.pnml
+++ b/src/vehiclesort.pnml
@@ -51,6 +51,7 @@ item_rbd_Germany_OHE_520_GDT, /*Year: 1953*/ \
 item_rbd_Belgium_SNCB_Class_42, /*Year: 1954*/ \
 item_rbd_Netherlands_NS_20_Kameel, /*Year: 1954*/ \
 item_rbd_Finland_VR_Dm7, /*Year: 1955*/ \
+item_rbd_Italy_FS_ALn_668, /*Year: 1956*/ \
 item_rbd_Bulgaria_BDZ_19, /*Year: 1960*/ \
 item_rbd_Chile_EFE_Buscarril, /*Year: 1961*/ \
 item_rbd_Greece_OSE_AA71, /*Year: 1962*/ \


### PR DESCRIPTION
Hi @Transportman,

While developing [althonos/2ccng](https://github.com/althonos/2ccng) and getting familiar with the code I noticed a few smal issues with the code, mainly:

- 2 locomotives and 1 wagon not having the proper vehicle code declared (e.g. `item_diesel_USA_GNR_SDP_40F` instead of `item_diesel_USA_Amtrack_SDP_40F`), which led to some issues with `2ccng`
- FS ALn 668 having the wrong purchase sprite and not being declared in the sort order (#3).

I know you are not actively developing this anymore, but I hope you can still merge this and make a small release, it would be greatly appreciated! Thanks :smiley: 